### PR TITLE
Enhancement: Added option to display on first/last monitor

### DIFF
--- a/etc/archlinux-logout.conf
+++ b/etc/archlinux-logout.conf
@@ -4,6 +4,7 @@ icon_size=64
 font_size=11
 # buttons=cancel,logout,restart,shutdown,suspend,hibernate,lock
 buttons=cancel,logout,restart,shutdown,suspend,hibernate,lock
+show_on_monitor=first
 
 [commands]
 lock=betterlockscreen -l dim -- --time-str="%H:%M"

--- a/usr/share/archlinux-logout/Functions.py
+++ b/usr/share/archlinux-logout/Functions.py
@@ -1,4 +1,3 @@
-
 # =====================================================
 #        Authors Brad Heffernan and Erik Dubois
 # =====================================================
@@ -8,9 +7,10 @@ import os
 import shutil
 from pathlib import Path
 import configparser
-#import distro
 
-envvar = os.environ['XDG_SESSION_TYPE']
+# import distro
+
+envvar = os.environ["XDG_SESSION_TYPE"]
 sessionw = False
 if envvar == "wayland":
     sessionw = True
@@ -19,13 +19,16 @@ home = os.path.expanduser("~")
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 # here = Path(__file__).resolve()
-working_dir = ''.join([str(Path(__file__).parents[2]), "/share/archlinux-logout-themes/"])
+working_dir = "".join(
+    [str(Path(__file__).parents[2]), "/share/archlinux-logout-themes/"]
+)
 # config = "/etc/archlinux-logout.conf"
 if os.path.isfile(home + "/.config/archlinux-logout/archlinux-logout.conf"):
     config = home + "/.config/archlinux-logout/archlinux-logout.conf"
 else:
-    config = ''.join([str(Path(__file__).parents[3]), "/etc/archlinux-logout.conf"])
-root_config = ''.join([str(Path(__file__).parents[3]), "/etc/archlinux-logout.conf"])
+    config = "".join([str(Path(__file__).parents[3]), "/etc/archlinux-logout.conf"])
+root_config = "".join([str(Path(__file__).parents[3]), "/etc/archlinux-logout.conf"])
+
 
 def _get_position(lists, value):
     data = [string for string in lists if value in string]
@@ -41,15 +44,19 @@ def _get_themes():
 
 def cache_bl(self, GLib, Gtk):
     if os.path.isfile("/usr/bin/betterlockscreen"):
-        with subprocess.Popen(["betterlockscreen", "-u",
-                               self.wallpaper],
-                              shell=False,
-                              stdout=subprocess.PIPE) as f:
+        with subprocess.Popen(
+            ["betterlockscreen", "-u", self.wallpaper],
+            shell=False,
+            stdout=subprocess.PIPE,
+        ) as f:
             for line in f.stdout:
                 line = str(line)
                 line = line.split(maxsplit=1)[1]
                 line = line[:-3]
-                GLib.idle_add(self.lbl_stat.set_markup, "<span size=\"x-large\"><b>" + line + "</b></span>")
+                GLib.idle_add(
+                    self.lbl_stat.set_markup,
+                    '<span size="x-large"><b>' + line + "</b></span>",
+                )
 
         GLib.idle_add(self.lbl_stat.set_text, "")
         os.unlink("/tmp/archlinux-logout.lock")
@@ -66,17 +73,20 @@ def get_config(self, Gdk, Gtk, config):
 
         # Set some safe defaults
         self.opacity = 60
+        self.show_on_monitor = 0  # always show on first monitor unless set in settings
 
         # Check if we're using HAL, and init it as required.
         if self.parser.has_section("settings"):
             if self.parser.has_option("settings", "opacity"):
-                self.opacity = int(self.parser.get("settings", "opacity"))/100
+                self.opacity = int(self.parser.get("settings", "opacity")) / 100
             if self.parser.has_option("settings", "buttons"):
                 self.buttons = self.parser.get("settings", "buttons").split(",")
             if self.parser.has_option("settings", "icon_size"):
                 self.icon = int(self.parser.get("settings", "icon_size"))
             if self.parser.has_option("settings", "font_size"):
                 self.font = int(self.parser.get("settings", "font_size"))
+            if self.parser.has_option("settings", "show_on_monitor"):
+                self.show_on_monitor = self.parser.get("settings", "show_on_monitor")
 
         if self.parser.has_section("commands"):
             if self.parser.has_option("commands", "lock"):
@@ -92,21 +102,27 @@ def get_config(self, Gdk, Gtk, config):
 
         if self.parser.has_section("binds"):
             if self.parser.has_option("binds", "lock"):
-                self.binds['lock'] = self.parser.get("binds", "lock").capitalize()
+                self.binds["lock"] = self.parser.get("binds", "lock").capitalize()
             if self.parser.has_option("binds", "restart"):
-                self.binds['restart'] = self.parser.get("binds", "restart").capitalize()
+                self.binds["restart"] = self.parser.get("binds", "restart").capitalize()
             if self.parser.has_option("binds", "shutdown"):
-                self.binds['shutdown'] = self.parser.get("binds", "shutdown").capitalize()
+                self.binds["shutdown"] = self.parser.get(
+                    "binds", "shutdown"
+                ).capitalize()
             if self.parser.has_option("binds", "suspend"):
-                self.binds['suspend'] = self.parser.get("binds", "suspend").capitalize()
+                self.binds["suspend"] = self.parser.get("binds", "suspend").capitalize()
             if self.parser.has_option("binds", "hibernate"):
-                self.binds['hibernate'] = self.parser.get("binds", "hibernate").capitalize()
+                self.binds["hibernate"] = self.parser.get(
+                    "binds", "hibernate"
+                ).capitalize()
             if self.parser.has_option("binds", "logout"):
-                self.binds['logout'] = self.parser.get("binds", "logout").capitalize()
+                self.binds["logout"] = self.parser.get("binds", "logout").capitalize()
             if self.parser.has_option("binds", "cancel"):
-                self.binds['cancel'] = self.parser.get("binds", "cancel").capitalize()
+                self.binds["cancel"] = self.parser.get("binds", "cancel").capitalize()
             if self.parser.has_option("binds", "settings"):
-                self.binds['settings'] = self.parser.get("binds", "settings").capitalize()
+                self.binds["settings"] = self.parser.get(
+                    "binds", "settings"
+                ).capitalize()
 
         if self.parser.has_section("themes"):
             if self.parser.has_option("themes", "theme"):
@@ -116,25 +132,32 @@ def get_config(self, Gdk, Gtk, config):
 
         if len(self.theme) > 1:
             style_provider = Gtk.CssProvider()
-            style_provider.load_from_path(working_dir + 'themes/' + self.theme + '/theme.css')
+            style_provider.load_from_path(
+                working_dir + "themes/" + self.theme + "/theme.css"
+            )
 
             Gtk.StyleContext.add_provider_for_screen(
                 Gdk.Screen.get_default(),
                 style_provider,
-                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
             )
     except Exception as e:
         print(e)
         os.unlink(home + "/.config/archlinux-logout/archlinux-logout.conf")
         if not os.path.isfile(home + "/.config/archlinux-logout/archlinux-logout.conf"):
-            shutil.copy(root_config, home + "/.config/archlinux-logout/archlinux-logout.conf")
+            shutil.copy(
+                root_config, home + "/.config/archlinux-logout/archlinux-logout.conf"
+            )
 
 
 def _get_logout():
     desktop = "unknown"
     try:
-        out = subprocess.run(["sh", "-c", "env | grep DESKTOP_SESSION"],
-                         shell=False, stdout=subprocess.PIPE)
+        out = subprocess.run(
+            ["sh", "-c", "env | grep DESKTOP_SESSION"],
+            shell=False,
+            stdout=subprocess.PIPE,
+        )
         desktop = out.stdout.decode().split("=")[1].strip()
         desktop = desktop.lower()
     except Exception as e:
@@ -142,11 +165,14 @@ def _get_logout():
 
     # in case display manager ly is active
 
-    status = os.system('systemctl is-active --quiet ly')
+    status = os.system("systemctl is-active --quiet ly")
     if status == 0:
         try:
-            out = subprocess.run(["sh", "-c", "env | grep XDG_CURRENT_DESKTOP"],
-                             shell=False, stdout=subprocess.PIPE)
+            out = subprocess.run(
+                ["sh", "-c", "env | grep XDG_CURRENT_DESKTOP"],
+                shell=False,
+                stdout=subprocess.PIPE,
+            )
             desktop = out.stdout.decode().split("=")[1].strip()
             desktop = desktop.lower()
         except Exception as e:
@@ -171,7 +197,7 @@ def _get_logout():
         return "pkill worm"
     elif desktop in ("berry", "/usr/share/xsessions/berry"):
         return "pkill berry"
-    #for lxdm
+    # for lxdm
     elif desktop in ("Xmonad", "/usr/share/xsessions/xmonad"):
         return "pkill xmonad"
     elif desktop in ("dwm", "/usr/share/xsessions/dwm"):
@@ -212,7 +238,7 @@ def _get_logout():
         return "gnome-session-quit --logout --no-prompt"
     elif desktop in ("gnome-classic", "/usr/share/xsessions/gnome-classic"):
         return "gnome-session-quit --logout --no-prompt"
-    #wayland desktops
+    # wayland desktops
     elif desktop in ("sway", "/usr/share/wayland-sessions/sway"):
         return "pkill sway"
     elif desktop in ("hyprland", "/usr/share/wayland-sessions/hyprland"):
@@ -223,49 +249,76 @@ def _get_logout():
         return "pkill wayfire"
     elif desktop in ("newm", "/usr/share/wayland-sessions/newm"):
         return "pkill newm"
-    elif desktop :
+    elif desktop:
         return "pkill awesome | pkill bspwm | pkill cwm |  pkill dwm | pkill dusk | pkill fvwm3 | pkill herbstluftwm | pkill i3 | pkill icewm | pkill jwm | pkill leftwm | pkill lxqt | pkill openbox | pkill qtile | pkill spectrwm | pkill wmderland | pkill xmonad | pkill worm | pkill berry | pkill Hypr | pkill hypr | pkill hyprland | pkill sway | pkill wayfire | pkill newm | pkill river"
     return None
 
+
 def button_active(self, data, GdkPixbuf):
     try:
-        if data == self.binds['shutdown']:
+        if data == self.binds["shutdown"]:
             psh = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/shutdown_blur.svg'), self.icon, self.icon)
+                os.path.join(
+                    working_dir, "themes/" + self.theme + "/shutdown_blur.svg"
+                ),
+                self.icon,
+                self.icon,
+            )
             self.imagesh.set_from_pixbuf(psh)
-            self.lbl1.set_markup("<span foreground=\"white\">Shutdown</span>")
-        elif data == self.binds['restart']:
+            self.lbl1.set_markup('<span foreground="white">Shutdown</span>')
+        elif data == self.binds["restart"]:
             pr = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/restart_blur.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/restart_blur.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imager.set_from_pixbuf(pr)
-            self.lbl2.set_markup("<span foreground=\"white\">Restart</span>")
-        elif data == self.binds['suspend']:
+            self.lbl2.set_markup('<span foreground="white">Restart</span>')
+        elif data == self.binds["suspend"]:
             ps = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/suspend_blur.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/suspend_blur.svg"),
+                self.icon,
+                self.icon,
+            )
             self.images.set_from_pixbuf(ps)
-            self.lbl3.set_markup("<span foreground=\"white\">Suspend</span>")
-        elif data == self.binds['lock']:
+            self.lbl3.set_markup('<span foreground="white">Suspend</span>')
+        elif data == self.binds["lock"]:
             plk = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/lock_blur.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/lock_blur.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagelk.set_from_pixbuf(plk)
-            self.lbl4.set_markup("<span foreground=\"white\">Lock</span>")
-        elif data == self.binds['logout']:
+            self.lbl4.set_markup('<span foreground="white">Lock</span>')
+        elif data == self.binds["logout"]:
             plo = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/logout_blur.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/logout_blur.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagelo.set_from_pixbuf(plo)
-            self.lbl5.set_markup("<span foreground=\"white\">Logout</span>")
-        elif data == self.binds['cancel']:
+            self.lbl5.set_markup('<span foreground="white">Logout</span>')
+        elif data == self.binds["cancel"]:
             plo = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/cancel_blur.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/cancel_blur.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagec.set_from_pixbuf(plo)
-            self.lbl6.set_markup("<span foreground=\"white\">Cancel</span>")
-        elif data == self.binds['hibernate']:
+            self.lbl6.set_markup('<span foreground="white">Cancel</span>')
+        elif data == self.binds["hibernate"]:
             plo = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/hibernate_blur.svg'), self.icon, self.icon)
+                os.path.join(
+                    working_dir, "themes/" + self.theme + "/hibernate_blur.svg"
+                ),
+                self.icon,
+                self.icon,
+            )
             self.imageh.set_from_pixbuf(plo)
-            self.lbl7.set_markup("<span foreground=\"white\">Hibernate</span>")
+            self.lbl7.set_markup('<span foreground="white">Hibernate</span>')
     except:
         pass
+
 
 def button_toggled(self, data):
     self.Esh.set_sensitive(False)
@@ -276,19 +329,19 @@ def button_toggled(self, data):
     self.Ec.set_sensitive(False)
     self.Eh.set_sensitive(False)
 
-    if data == self.binds['shutdown']:
+    if data == self.binds["shutdown"]:
         self.Esh.set_sensitive(True)
-    elif data == self.binds['restart']:
+    elif data == self.binds["restart"]:
         self.Er.set_sensitive(True)
-    elif data == self.binds['suspend']:
+    elif data == self.binds["suspend"]:
         self.Es.set_sensitive(True)
-    elif data == self.binds['lock']:
+    elif data == self.binds["lock"]:
         self.Elk.set_sensitive(True)
-    elif data == self.binds['logout']:
+    elif data == self.binds["logout"]:
         self.El.set_sensitive(True)
-    elif data == self.binds['cancel']:
+    elif data == self.binds["cancel"]:
         self.Ec.set_sensitive(True)
-    elif data == self.binds['hibernate']:
+    elif data == self.binds["hibernate"]:
         self.Eh.set_sensitive(True)
 
 
@@ -296,6 +349,12 @@ def file_check(file):
     if os.path.isfile(file):
         return True
 
-#def get_distro(self):
-#print(distro.id())
+
+# def get_distro(self):
+# print(distro.id())
 #    return(distro.id())
+
+
+# get number of monitors
+def get_monitors(display):
+    return display.get_n_monitors()

--- a/usr/share/archlinux-logout/GUI.py
+++ b/usr/share/archlinux-logout/GUI.py
@@ -1,4 +1,3 @@
-
 # =====================================================
 #        Authors Brad Heffernan and Erik Dubois
 # =====================================================
@@ -28,27 +27,33 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
 
     self.Eset = Gtk.EventBox()
     self.Eset.set_name("settings")
-    self.Eset.connect("button_press_event", self.on_click, self.binds['settings'])
+    self.Eset.connect("button_press_event", self.on_click, self.binds["settings"])
     self.Eset.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Eset.connect("enter-notify-event", self.on_mouse_in, self.binds['settings'])  # 2
+    self.Eset.connect(
+        "enter-notify-event", self.on_mouse_in, self.binds["settings"]
+    )  # 2
     self.Eset.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Eset.connect("leave-notify-event", self.on_mouse_out, self.binds['settings'])  # 2
+    self.Eset.connect(
+        "leave-notify-event", self.on_mouse_out, self.binds["settings"]
+    )  # 2
 
     pset = GdkPixbuf.Pixbuf().new_from_file_at_size(
-        os.path.join(working_dir, 'configure.svg'), 48, 48)
+        os.path.join(working_dir, "configure.svg"), 48, 48
+    )
     self.imageset = Gtk.Image().new_from_pixbuf(pset)
     self.Eset.add(self.imageset)
 
     self.Elig = Gtk.EventBox()
     self.Elig.set_name("light")
-    self.Elig.connect("button_press_event", self.on_click, 'light')
+    self.Elig.connect("button_press_event", self.on_click, "light")
     self.Elig.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Elig.connect("enter-notify-event", self.on_mouse_in, 'light')
+    self.Elig.connect("enter-notify-event", self.on_mouse_in, "light")
     self.Elig.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Elig.connect("leave-notify-event", self.on_mouse_out, 'light')
+    self.Elig.connect("leave-notify-event", self.on_mouse_out, "light")
 
     plig = GdkPixbuf.Pixbuf().new_from_file_at_size(
-        os.path.join(working_dir, 'light.svg'), 48, 48)
+        os.path.join(working_dir, "light.svg"), 48, 48
+    )
     self.imagelig = Gtk.Image().new_from_pixbuf(plig)
     self.Elig.add(self.imagelig)
 
@@ -64,111 +69,140 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     hbox1 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=30)
 
     self.Esh = Gtk.EventBox()
-    self.Esh.connect("button_press_event", self.on_click, self.binds['shutdown'])
+    self.Esh.connect("button_press_event", self.on_click, self.binds["shutdown"])
     self.Esh.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Esh.connect("enter-notify-event", self.on_mouse_in, self.binds['shutdown'])  # 2
+    self.Esh.connect(
+        "enter-notify-event", self.on_mouse_in, self.binds["shutdown"]
+    )  # 2
     self.Esh.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Esh.connect("leave-notify-event", self.on_mouse_out, self.binds['shutdown'])  # 2
+    self.Esh.connect(
+        "leave-notify-event", self.on_mouse_out, self.binds["shutdown"]
+    )  # 2
 
     self.Er = Gtk.EventBox()
-    self.Er.connect("button_press_event", self.on_click, self.binds['restart'])
+    self.Er.connect("button_press_event", self.on_click, self.binds["restart"])
     self.Er.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Er.connect("enter-notify-event", self.on_mouse_in, self.binds['restart'])  # 2
+    self.Er.connect("enter-notify-event", self.on_mouse_in, self.binds["restart"])  # 2
     self.Er.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Er.connect("leave-notify-event", self.on_mouse_out, self.binds['restart'])  # 2
+    self.Er.connect("leave-notify-event", self.on_mouse_out, self.binds["restart"])  # 2
 
     self.Es = Gtk.EventBox()
-    self.Es.connect("button_press_event", self.on_click, self.binds['suspend'])
+    self.Es.connect("button_press_event", self.on_click, self.binds["suspend"])
     self.Es.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Es.connect("enter-notify-event", self.on_mouse_in, self.binds['suspend'])  # 2
+    self.Es.connect("enter-notify-event", self.on_mouse_in, self.binds["suspend"])  # 2
     self.Es.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Es.connect("leave-notify-event", self.on_mouse_out, self.binds['suspend'])  # 2
+    self.Es.connect("leave-notify-event", self.on_mouse_out, self.binds["suspend"])  # 2
 
     self.Elk = Gtk.EventBox()
-    self.Elk.connect("button_press_event", self.on_click, self.binds['lock'])
+    self.Elk.connect("button_press_event", self.on_click, self.binds["lock"])
     self.Elk.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Elk.connect("enter-notify-event", self.on_mouse_in, self.binds['lock'])  # 2
+    self.Elk.connect("enter-notify-event", self.on_mouse_in, self.binds["lock"])  # 2
     self.Elk.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Elk.connect("leave-notify-event", self.on_mouse_out, self.binds['lock'])  # 2
+    self.Elk.connect("leave-notify-event", self.on_mouse_out, self.binds["lock"])  # 2
 
     self.El = Gtk.EventBox()
-    self.El.connect("button_press_event", self.on_click, self.binds['logout'])
+    self.El.connect("button_press_event", self.on_click, self.binds["logout"])
     self.El.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.El.connect("enter-notify-event", self.on_mouse_in, self.binds['logout'])  # 2
+    self.El.connect("enter-notify-event", self.on_mouse_in, self.binds["logout"])  # 2
     self.El.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.El.connect("leave-notify-event", self.on_mouse_out, self.binds['logout'])  # 2
+    self.El.connect("leave-notify-event", self.on_mouse_out, self.binds["logout"])  # 2
 
     self.Ec = Gtk.EventBox()
-    self.Ec.connect("button_press_event", self.on_click, self.binds['cancel'])
+    self.Ec.connect("button_press_event", self.on_click, self.binds["cancel"])
     self.Ec.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Ec.connect("enter-notify-event", self.on_mouse_in, self.binds['cancel'])  # 2
+    self.Ec.connect("enter-notify-event", self.on_mouse_in, self.binds["cancel"])  # 2
     self.Ec.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Ec.connect("leave-notify-event", self.on_mouse_out, self.binds['cancel'])  # 2
+    self.Ec.connect("leave-notify-event", self.on_mouse_out, self.binds["cancel"])  # 2
 
     self.Eh = Gtk.EventBox()
-    self.Eh.connect("button_press_event", self.on_click, self.binds['hibernate'])
+    self.Eh.connect("button_press_event", self.on_click, self.binds["hibernate"])
     self.Eh.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)  # 1
-    self.Eh.connect("enter-notify-event", self.on_mouse_in, self.binds['hibernate'])  # 2
+    self.Eh.connect(
+        "enter-notify-event", self.on_mouse_in, self.binds["hibernate"]
+    )  # 2
     self.Eh.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)  # 1
-    self.Eh.connect("leave-notify-event", self.on_mouse_out, self.binds['hibernate'])  # 2
+    self.Eh.connect(
+        "leave-notify-event", self.on_mouse_out, self.binds["hibernate"]
+    )  # 2
 
     for button in self.buttons:
         if button == "shutdown":
             psh = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/shutdown.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/shutdown.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagesh = Gtk.Image().new_from_pixbuf(psh)
             self.Esh.add(self.imagesh)
         if button == "cancel":
             pc = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/cancel.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/cancel.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagec = Gtk.Image().new_from_pixbuf(pc)
             self.Ec.add(self.imagec)
         if button == "restart":
             pr = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/restart.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/restart.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imager = Gtk.Image().new_from_pixbuf(pr)
             self.Er.add(self.imager)
         if button == "suspend":
             ps = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/suspend.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/suspend.svg"),
+                self.icon,
+                self.icon,
+            )
             self.images = Gtk.Image().new_from_pixbuf(ps)
             self.Es.add(self.images)
         if button == "lock":
             plk = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/lock.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/lock.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagelk = Gtk.Image().new_from_pixbuf(plk)
             self.Elk.add(self.imagelk)
         if button == "logout":
             plo = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/logout.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/logout.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imagelo = Gtk.Image().new_from_pixbuf(plo)
             self.El.add(self.imagelo)
         if button == "hibernate":
             ph = GdkPixbuf.Pixbuf().new_from_file_at_size(
-                os.path.join(working_dir, 'themes/' + self.theme + '/hibernate.svg'), self.icon, self.icon)
+                os.path.join(working_dir, "themes/" + self.theme + "/hibernate.svg"),
+                self.icon,
+                self.icon,
+            )
             self.imageh = Gtk.Image().new_from_pixbuf(ph)
             self.Eh.add(self.imageh)
 
     self.lbl1 = Gtk.Label()
-    self.lbl1.set_markup("<span size=\"" + str(self.font) + "000\">Shutdown (S)</span>")
+    self.lbl1.set_markup('<span size="' + str(self.font) + '000">Shutdown (S)</span>')
     self.lbl1.set_name("lbl")
     self.lbl2 = Gtk.Label()
-    self.lbl2.set_markup("<span size=\"" + str(self.font) + "000\">Reboot (R)</span>")
+    self.lbl2.set_markup('<span size="' + str(self.font) + '000">Reboot (R)</span>')
     self.lbl2.set_name("lbl")
     self.lbl3 = Gtk.Label()
-    self.lbl3.set_markup("<span size=\"" + str(self.font) + "000\">Suspend (U)</span>")
+    self.lbl3.set_markup('<span size="' + str(self.font) + '000">Suspend (U)</span>')
     self.lbl3.set_name("lbl")
     self.lbl4 = Gtk.Label()
-    self.lbl4.set_markup("<span size=\"" + str(self.font) + "000\">Lock (K)</span>")
+    self.lbl4.set_markup('<span size="' + str(self.font) + '000">Lock (K)</span>')
     self.lbl4.set_name("lbl")
     self.lbl5 = Gtk.Label()
-    self.lbl5.set_markup("<span size=\"" + str(self.font) + "000\">Logout (L)</span>")
+    self.lbl5.set_markup('<span size="' + str(self.font) + '000">Logout (L)</span>')
     self.lbl5.set_name("lbl")
     self.lbl6 = Gtk.Label()
-    self.lbl6.set_markup("<span size=\"" + str(self.font) + "000\">Cancel (ESC)</span>")
+    self.lbl6.set_markup('<span size="' + str(self.font) + '000">Cancel (ESC)</span>')
     self.lbl6.set_name("lbl")
     self.lbl7 = Gtk.Label()
-    self.lbl7.set_markup("<span size=\"" + str(self.font) + "000\">Hibernate (H)</span>")
+    self.lbl7.set_markup('<span size="' + str(self.font) + '000">Hibernate (H)</span>')
     self.lbl7.set_name("lbl")
 
     vbox1.pack_start(self.Esh, False, False, 0)
@@ -205,60 +239,55 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
 
     mainbox2.pack_start(hbox1, True, False, 0)
 
-    # mainbox4.pack_start(self.Elig, False, False, 0)
-
-    # mainbox3.pack_end(mainbox4, False, False, 0)
-
     # spacers
     hbox17.pack_start(self.Elig, False, False, 0)
     hbox17.pack_start(self.Eset, False, False, 0)
     mainbox.pack_start(hbox17, False, False, 0)
-    # mainbox.pack_start(Gtk.Label(), False, False, 0)
-    # mainbox.pack_start(Gtk.Label(), False, False, 0)
 
-    # mainbox.pack_end(mainbox3, False, False, 0)
     mainbox.pack_start(mainbox2, True, False, 0)
-    # mainbox.set_size_request(self.single_width, 0)
-    # container.pack_start(mainbox, False, False, 0)
-    # if self.single_width < self.width:
-    #     container.pack_start(spacer, True, True, 0)
-    #     spacer.pack_start(Gtk.Label(label=""), True, True, 0)
 
     self.popover = Gtk.Popover()
     self.popover2 = Gtk.Popover()
     vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-    hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
-    hbox3 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
-    hbox4 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
-    hbox5 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
-    hbox6 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
+    vbox.set_border_width(10)
 
-    lbl8 = Gtk.Label(label="Opacity:")
-    lbl9 = Gtk.Label(label="Icon size:")
-    lbl10 = Gtk.Label(label="Theme:")
-    lbl11 = Gtk.Label(label="Font size:")
+    lbl_opacity = Gtk.Label()
+    lbl_opacity.set_markup("<b>Opacity:</b>")
+    lbl_opacity.set_halign(Gtk.Align.START)
+    lbl_opacity.set_valign(Gtk.Align.END)
+
+    lbl_icon_size = Gtk.Label()
+    lbl_icon_size.set_markup("<b>Icon size:</b>")
+    lbl_icon_size.set_halign(Gtk.Align.START)
+    lbl_icon_size.set_valign(Gtk.Align.END)
+
+    lbl_theme = Gtk.Label()
+    lbl_theme.set_markup("<b>Theme:</b>")
+    lbl_theme.set_halign(Gtk.Align.START)
+    lbl_theme.set_valign(Gtk.Align.CENTER)
+
+    lbl_font_size = Gtk.Label()
+    lbl_font_size.set_markup("<b>Font size:</b>")
+    lbl_font_size.set_halign(Gtk.Align.START)
+    lbl_font_size.set_valign(Gtk.Align.END)
+
+    lbl_monitors = Gtk.Label()
+    lbl_monitors.set_markup("<b>Display:</b>")
+    lbl_monitors.set_halign(Gtk.Align.START)
+    lbl_monitors.set_valign(Gtk.Align.CENTER)
+
     # lbl11 = Gtk.Label(label="Wallpaper:")
     try:
-        vals = self.opacity*100
+        vals = self.opacity * 100
         ad1 = Gtk.Adjustment(vals, 0, 100, 5, 10, 0)
     except:
         ad1 = Gtk.Adjustment(60, 0, 100, 5, 10, 0)
 
-    self.hscale = Gtk.Scale(
-        orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1)
+    self.hscale = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1)
     self.hscale.set_digits(0)
     self.hscale.set_hexpand(True)
     self.hscale.set_size_request(150, 0)
     self.hscale.set_valign(Gtk.Align.START)
-    # self.wall = Gtk.Entry()
-    # self.wall.set_size_request(180, 0)
-    # self.wall.set_width_chars(True)
-    # self.wall.set_text(self.wallpaper)
-
-    # self.hscale = Gtk.Entry()
-    # self.hscale.set_size_request(80, 0)
-    # self.hscale.set_width_chars(True)
-    # self.hscale.set_text(str(int(self.opacity*100)))
 
     try:
         vals = self.font
@@ -266,8 +295,7 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     except:
         ad1f = Gtk.Adjustment(60, 0, 80, 5, 10, 0)
 
-    self.fonts = Gtk.Scale(
-        orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1f)
+    self.fonts = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1f)
     self.fonts.set_digits(0)
     self.fonts.set_hexpand(True)
     self.fonts.set_size_request(150, 0)
@@ -279,24 +307,16 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     except:
         ad1i = Gtk.Adjustment(60, 0, 300, 5, 10, 0)
 
-    self.icons = Gtk.Scale(
-        orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1i)
+    self.icons = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL, adjustment=ad1i)
     self.icons.set_digits(0)
     self.icons.set_hexpand(True)
     self.icons.set_size_request(150, 0)
     self.icons.set_valign(Gtk.Align.START)
 
-    # self.icons = Gtk.Entry()
-    # self.icons.set_size_request(80, 0)
-    # self.icons.set_width_chars(True)
-    # self.icons.set_text(str(self.icon))
-
-    # self.hovers = Gtk.Entry()
-    # self.hovers.set_size_request(80, 0)
-    # self.hovers.set_width_chars(True)
-    # self.hovers.set_text(str(self.hover))
-
     self.themes = Gtk.ComboBoxText()
+    # set the wrap width to stop the combobox list from stretching
+    self.themes.set_wrap_width(2)
+
     lists = fn._get_themes()
     active = 0
     for x in range(len(lists)):
@@ -305,28 +325,75 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
             active = x
     self.themes.set_active(active)
 
-    btn = Gtk.Button(label="Save Settings")
-    btn.connect('clicked', self.on_save_clicked)
+    vbox_monitors = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+    self.rb_monitor_first = Gtk.RadioButton(label="First monitor")
+    self.rb_monitor_first.set_name("rb_monitor_first")
 
-    hbox3.pack_end(btn, False, False, 10)
+    vbox_monitors.pack_start(self.rb_monitor_first, True, True, 0)
 
-    hbox.pack_start(lbl8, False, False, 10)
-    hbox.pack_end(self.hscale, False, False, 10)
+    # override self.monitors for testing ui
+    if self.monitors > 0:
+        if self.monitors > 1:
+            self.rb_monitor_last = Gtk.RadioButton(
+                label="Last monitor", group=self.rb_monitor_first
+            )
+            self.rb_monitor_last.set_name("rb_monitor_last")
 
-    hbox4.pack_start(lbl9, False, False, 10)
-    hbox4.pack_end(self.icons, False, False, 10)
+            vbox_monitors.pack_end(self.rb_monitor_last, True, True, 0)
 
-    hbox5.pack_start(lbl10, False, False, 10)
-    hbox5.pack_end(self.themes, False, False, 10)
+            if self.show_on_monitor == "first":
+                self.rb_monitor_first.set_active(True)
 
-    hbox6.pack_start(lbl11, False, False, 10)
-    hbox6.pack_end(self.fonts, False, False, 10)
+            if self.show_on_monitor == "last":
+                self.rb_monitor_last.set_active(True)
 
-    vbox.pack_start(hbox, False, True, 10)
-    vbox.pack_start(hbox4, False, True, 10)
-    vbox.pack_start(hbox6, False, True, 10)
-    vbox.pack_start(hbox5, False, True, 10)
-    vbox.pack_end(hbox3, False, True, 10)
+    else:
+        # this is an error should not reach here
+        print("[ERROR]: Failed to retrieve list of monitors")
+
+    btn_save_settings = Gtk.Button(label="Save Settings")
+    btn_save_settings.connect("clicked", self.on_save_clicked)
+
+    # create hbox to store settings
+
+    hbox_opacity = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+    hbox_opacity.pack_start(lbl_opacity, False, False, 5)
+    hbox_opacity.pack_start(self.hscale, False, False, 5)
+
+    hbox_icon_size = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+    hbox_icon_size.pack_start(lbl_icon_size, False, False, 5)
+    hbox_icon_size.pack_start(self.icons, False, False, 5)
+
+    hbox_font_size = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+    hbox_font_size.pack_start(lbl_font_size, False, False, 5)
+    hbox_font_size.pack_start(self.fonts, False, False, 5)
+
+    hbox_theme = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
+    hbox_theme.pack_start(lbl_theme, False, False, 5)
+    hbox_theme.pack_start(self.themes, False, False, 5)
+
+    # use a fixed container to align the monitor radio buttons with the label
+
+    fixed_container = Gtk.Fixed()
+    fixed_container.put(lbl_monitors, 5, 0)
+    fixed_container.put(vbox_monitors, 75, -1)
+
+    hbox_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+    hbox_buttons.pack_start(btn_save_settings, False, False, 5)
+
+    grid_settings = Gtk.Grid()
+    grid_settings.set_row_spacing(20)
+
+    # attach hbox settings to grid
+    grid_settings.attach(hbox_opacity, 0, 1, 1, 1)
+    grid_settings.attach(hbox_icon_size, 0, 2, 1, 1)
+    grid_settings.attach(hbox_font_size, 0, 3, 1, 1)
+    grid_settings.attach(hbox_theme, 0, 4, 1, 1)
+    grid_settings.attach(fixed_container, 0, 5, 1, 1)
+
+    grid_settings.attach(hbox_buttons, 0, 6, 1, 1)
+
+    vbox.pack_start(grid_settings, True, True, 10)
 
     self.popover.add(vbox)
     self.popover.set_position(Gtk.PositionType.TOP)
@@ -334,7 +401,9 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     hbox8 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
 
     plbl = Gtk.Label()
-    plbl.set_markup("<span size=\"large\">You can change the lockscreen wallpaper\nwith <b>Archlinux BetterLockScreen</b></span>")
+    plbl.set_markup(
+        '<span size="large">You can change the lockscreen wallpaper\nwith <b>Archlinux BetterLockScreen</b></span>'
+    )
 
     hbox8.pack_end(plbl, False, False, 10)
 

--- a/usr/share/archlinux-logout/archlinux-logout.py
+++ b/usr/share/archlinux-logout/archlinux-logout.py
@@ -111,23 +111,7 @@ class TransparentWindow(Gtk.Window):
         # get all monitors
         self.monitors = fn.get_monitors(display)
 
-        # loop through monitors, get resolution and set_size_request using the width, height dimensions
         print(f"[INFO] Available Monitors = {self.monitors}")
-
-        # monitor = display.get_monitor(0)
-        # geometry = monitor.get_geometry()
-        # print(f"[INFO] Setting Monitor: {geometry.width}x{geometry.height}")
-        # self.set_size_request(geometry.width, geometry.height)
-        # self.fullscreen_on_monitor(screen, 0)
-
-        # monitor = screens.get_monitor(0)
-        # rect = monitor.get_geometry()
-
-        # self.single_width = rect.width
-        # height = rect.height
-
-        # self.move(0, 0)
-        # self.resize(self.width, height)
 
         visual = screen.get_rgba_visual()
         if visual and screen.is_composited():
@@ -135,33 +119,7 @@ class TransparentWindow(Gtk.Window):
 
         fn.get_config(self, Gdk, Gtk, fn.config)
 
-        # check monitor value stored in the config file is still valid
-        # scenario: a connected monitor previously saved in the config may no longer be attached
-
-        if self.show_on_monitor == "first":
-            print("[INFO] Showing on first monitor")
-            monitor = display.get_monitor(0)
-            geometry = monitor.get_geometry()
-            print(f"[INFO] Setting Monitor: {geometry.width}x{geometry.height}")
-            self.set_size_request(geometry.width, geometry.height)
-            self.fullscreen_on_monitor(screen, 0)
-        elif self.show_on_monitor == "last" and self.monitors > 1:
-            # make sure the number of monitors is greater than 1 to show on last monitor
-            print("[INFO] Showing on last monitor")
-            for i in range(self.monitors):
-                monitor = display.get_monitor(i)
-                geometry = monitor.get_geometry()
-                print(f"[INFO] Setting Monitor: {geometry.width}x{geometry.height}")
-                self.set_size_request(geometry.width, geometry.height)
-                self.fullscreen_on_monitor(screen, i)
-        else:
-            # default show on first monitor
-            print("[INFO] Default action, showing on first monitor")
-            monitor = display.get_monitor(0)
-            geometry = monitor.get_geometry()
-            print(f"[INFO] Setting Monitor: {geometry.width}x{geometry.height}")
-            self.set_size_request(geometry.width, geometry.height)
-            self.fullscreen_on_monitor(screen, 0)
+        self.display_on_monitor(display, screen)
 
         if self.buttons is None or self.buttons == [""]:
             self.buttons = self.d_buttons
@@ -173,6 +131,33 @@ class TransparentWindow(Gtk.Window):
         if not fn.os.path.isfile("/tmp/archlinux-logout.lock"):
             with open("/tmp/archlinux-logout.lock", "w") as f:
                 f.write("")
+
+    def display_on_monitor(self, display, screen):
+        if self.show_on_monitor == "first":
+            monitor = display.get_monitor(0)
+            geometry = monitor.get_geometry()
+            print("[INFO] Showing on first monitor")
+            print(f"[INFO] Dimension = {geometry.width}x{geometry.height}")
+            self.set_size_request(geometry.width, geometry.height)
+            self.fullscreen_on_monitor(screen, 0)
+        elif self.show_on_monitor == "last" and self.monitors > 1:
+            # make sure the number of monitors is greater than 1 to show on last monitor
+            print("[INFO] Showing on last monitor")
+            # loop through monitors, get resolution and set_size_request using the width, height dimensions
+            for i in range(self.monitors):
+                monitor = display.get_monitor(i)
+                geometry = monitor.get_geometry()
+                print(f"[INFO] Monitor dimension = {geometry.width}x{geometry.height}")
+                self.set_size_request(geometry.width, geometry.height)
+                self.fullscreen_on_monitor(screen, i)
+        else:
+            # default show on first monitor
+            monitor = display.get_monitor(0)
+            geometry = monitor.get_geometry()
+            print("[INFO] Showing on first monitor")
+            print(f"[INFO] Dimension = {geometry.width}x{geometry.height}")
+            self.set_size_request(geometry.width, geometry.height)
+            self.fullscreen_on_monitor(screen, 0)
 
     def on_save_clicked(self, widget):
         try:


### PR DESCRIPTION
# Changes

- Added configuration setting to show the logout window on the first/last monitor
- By default the logout window will now open on the first monitor
- Added a grid layout to the settings popup to align all components properly
- Themes list is separated into 2 columns, rather than a single long list
- /etc/archlinux-logout/archlinux-logout.conf  is updated with `show_on_monitor=first` this is not necessary but was added to reflect the changes made

- Clicking save will update:

$HOME/.config/archlinux-logout/archlinux-logout.conf with `show_on_monitor=first` or `show_on_monitor=last` depending on what is selected.

# User has more than 1 monitor
![arco_qtile-multi-monitor](https://github.com/arcolinux/archlinux-logout-dev/assets/121581829/f0cd5c1f-c04f-4b0e-a249-a20993364ed1)

# User has only 1 monitor
![arco_qtile-single-monitor](https://github.com/arcolinux/archlinux-logout-dev/assets/121581829/222f2e61-7bc2-4e22-a266-f7b7ea0b9b6f)
