### PR TITLE
Move window to position of mouse cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # ArchLinux logout
+
+This widget, displays a transparent window allowing quick access to various power features:
+
+- Logout (L)
+- Reboot (R)
+- Shutdown (S)
+- Suspend (U)
+- Hibernate (H)
+- Lock (K)
+
+Additional configuration provided includes:
+
+- Setting the widget opacity
+- Icon size
+- Font size
+- Theme selection
+- Displaying the widget on the first/last monitor
+

--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ Additional configuration provided includes:
 - Icon size
 - Font size
 - Theme selection
-- Displaying the widget on the first/last monitor
+
+
 

--- a/etc/archlinux-logout.conf
+++ b/etc/archlinux-logout.conf
@@ -4,7 +4,6 @@ icon_size=64
 font_size=11
 # buttons=cancel,logout,restart,shutdown,suspend,hibernate,lock
 buttons=cancel,logout,restart,shutdown,suspend,hibernate,lock
-show_on_monitor=first
 
 [commands]
 lock=betterlockscreen -l dim -- --time-str="%H:%M"

--- a/usr/share/archlinux-logout/Functions.py
+++ b/usr/share/archlinux-logout/Functions.py
@@ -353,8 +353,3 @@ def file_check(file):
 # def get_distro(self):
 # print(distro.id())
 #    return(distro.id())
-
-
-# get number of monitors
-def get_monitors(display):
-    return display.get_n_monitors()

--- a/usr/share/archlinux-logout/GUI.py
+++ b/usr/share/archlinux-logout/GUI.py
@@ -271,11 +271,6 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     lbl_font_size.set_halign(Gtk.Align.START)
     lbl_font_size.set_valign(Gtk.Align.END)
 
-    lbl_monitors = Gtk.Label()
-    lbl_monitors.set_markup("<b>Display:</b>")
-    lbl_monitors.set_halign(Gtk.Align.START)
-    lbl_monitors.set_valign(Gtk.Align.CENTER)
-
     # lbl11 = Gtk.Label(label="Wallpaper:")
     try:
         vals = self.opacity * 100
@@ -325,32 +320,6 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
             active = x
     self.themes.set_active(active)
 
-    vbox_monitors = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
-    self.rb_monitor_first = Gtk.RadioButton(label="First monitor")
-    self.rb_monitor_first.set_name("rb_monitor_first")
-
-    vbox_monitors.pack_start(self.rb_monitor_first, True, True, 0)
-
-    # override self.monitors for testing ui
-    if self.monitors > 0:
-        if self.monitors > 1:
-            self.rb_monitor_last = Gtk.RadioButton(
-                label="Last monitor", group=self.rb_monitor_first
-            )
-            self.rb_monitor_last.set_name("rb_monitor_last")
-
-            vbox_monitors.pack_end(self.rb_monitor_last, True, True, 0)
-
-            if self.show_on_monitor == "first":
-                self.rb_monitor_first.set_active(True)
-
-            if self.show_on_monitor == "last":
-                self.rb_monitor_last.set_active(True)
-
-    else:
-        # this is an error should not reach here
-        print("[ERROR]: Failed to retrieve list of monitors")
-
     btn_save_settings = Gtk.Button(label="Save Settings")
     btn_save_settings.connect("clicked", self.on_save_clicked)
 
@@ -372,12 +341,6 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     hbox_theme.pack_start(lbl_theme, False, False, 5)
     hbox_theme.pack_start(self.themes, False, False, 5)
 
-    # use a fixed container to align the monitor radio buttons with the label
-
-    fixed_container = Gtk.Fixed()
-    fixed_container.put(lbl_monitors, 5, 0)
-    fixed_container.put(vbox_monitors, 75, -1)
-
     hbox_buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
     hbox_buttons.pack_start(btn_save_settings, False, False, 5)
 
@@ -389,7 +352,6 @@ def GUI(self, Gtk, GdkPixbuf, working_dir, os, Gdk, fn):
     grid_settings.attach(hbox_icon_size, 0, 2, 1, 1)
     grid_settings.attach(hbox_font_size, 0, 3, 1, 1)
     grid_settings.attach(hbox_theme, 0, 4, 1, 1)
-    grid_settings.attach(fixed_container, 0, 5, 1, 1)
 
     grid_settings.attach(hbox_buttons, 0, 6, 1, 1)
 


### PR DESCRIPTION
# Changes

- Removed first screen/last screen options
- Window shown is based on the monitor where the position of the mouse cursor is
- Added a few debug logging messages to console but can be removed

```bash #### Archlinux Logout ####
[DEBUG]: Session type = x11
[DEBUG]: Mouse position x=405 y=475
[DEBUG]: Monitor: Primary=True, Height=241, Width=447
[DEBUG]: Monitor: Dimension=1690x912
```

## X11/Wayland compatibility

The mouse cursor position can only be captured in a X11 session, on Wayland this is not possible to do using the GDK library.
On Wayland the behavior defaults to showing on the first monitor.

## Testing

Tested on only 1 monitor setup across QTile, Plasma - Wayland/X11, Chadwm, i3, XFCE